### PR TITLE
QMK Configurator update for the Pearl 40%

### DIFF
--- a/keyboards/pearl/info.json
+++ b/keyboards/pearl/info.json
@@ -1,0 +1,13 @@
+{
+  "keyboard_name": "Pearl", 
+  "url": "", 
+  "maintainer": "qmk", 
+  "bootloader": "", 
+  "width": 13, 
+  "height": 4, 
+  "layouts": {
+    "LAYOUT": {
+      "layout": [{"label":"Esc", "x":0, "y":0}, {"label":"Q", "x":1, "y":0}, {"label":"W", "x":2, "y":0}, {"label":"E", "x":3, "y":0}, {"label":"R", "x":4, "y":0}, {"label":"T", "x":5, "y":0}, {"label":"Y", "x":6, "y":0}, {"label":"U", "x":7, "y":0}, {"label":"I", "x":8, "y":0}, {"label":"O", "x":9, "y":0}, {"label":"P", "x":10, "y":0}, {"label":"{", "x":11, "y":0}, {"label":"Backspace", "x":12, "y":0}, {"label":"Tab", "x":0, "y":1, "w":1.5}, {"label":"A", "x":1.5, "y":1}, {"label":"S", "x":2.5, "y":1}, {"label":"D", "x":3.5, "y":1}, {"label":"F", "x":4.5, "y":1}, {"label":"G", "x":5.5, "y":1}, {"label":"H", "x":6.5, "y":1}, {"label":"J", "x":7.5, "y":1}, {"label":"K", "x":8.5, "y":1}, {"label":"L", "x":9.5, "y":1}, {"label":":", "x":10.5, "y":1}, {"label":"\\", "x":11.5, "y":1, "w":1.5}, {"label":"Caps Lock", "x":0, "y":2, "w":1.75}, {"label":"Z", "x":1.75, "y":2}, {"label":"X", "x":2.75, "y":2}, {"label":"C", "x":3.75, "y":2}, {"label":"V", "x":4.75, "y":2}, {"label":"B", "x":5.75, "y":2}, {"label":"N", "x":6.75, "y":2}, {"label":"M", "x":7.75, "y":2}, {"label":"<", "x":8.75, "y":2}, {"label":">", "x":9.75, "y":2}, {"label":"?", "x":10.75, "y":2}, {"label":"Shift", "x":11.75, "y":2, "w":1.25}, {"label":"Alt", "x":1.13, "y":3}, {"label":"Ctrl", "x":2.13, "y":3, "w":1.25}, {"label":"Win", "x":3.375, "y":3, "w":1.25}, {"label":"Shift", "x":4.625, "y":3, "w":2.25}, {"x":6.875, "y":3, "w":1.25}, {"x":8.125, "y":3, "w":1.5}, {"label":"Menu", "x":9.625, "y":3}, {"label":"Fn", "x":10.63, "y":3, "w":1.25}]
+    }
+  }
+}

--- a/keyboards/pearl/pearl.h
+++ b/keyboards/pearl/pearl.h
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "quantum.h"
 #include "pearl.h"
 
-#define KEYMAP( \
+#define LAYOUT( \
   K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C,\
    K10,  K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A,  K1B, \
     K20,  K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B,\


### PR DESCRIPTION
My attempt to get the physical layout as displayed in the [Configurator](https://config.qmk.fm/) more true-to-life. Intend to do more of these once I get more comfortable with QMK source. Having to familiarize myself with `keymap.c`s and `keyboard.h`s. Just a small update to see if I've done this properly.

`keyboards/pearl/pearl.h` was also updated to change `KEYMAP` to `LAYOUT` per instructions received from /u/merlin36 (MechMerlin) on reddit, who stated in a PM that `KEYMAP` is deprecated.